### PR TITLE
Adding simple install scripts for a robust setup, for more experiments

### DIFF
--- a/00-run-k8s.sh
+++ b/00-run-k8s.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+header_text "Starting Knative on kind!"
+
+if [ $(uname) != "Darwin" ]; then
+    export KIND_EXPERIMENTAL_PROVIDER=podman
+fi
+kind create cluster --image=${K8S_IMAGE}
+header_text "Waiting for core k8s services to initialize"
+kubectl cluster-info --context kind-kind
+sleep 5; while echo && kubectl get pods -n kube-system | grep -v -E "(Running|Completed|STATUS)"; do sleep 5; done
+
+kubectl -n kube-system get configmap coredns -o yaml | sed 's/\/etc\/resolv.conf/8.8.8.8/gi' | kubectl apply -f -
+PODNAMES=(`kubectl -n kube-system get pods -o jsonpath='{.items[*].metadata.name}'`)
+for name in ${PODNAMES[@]}; do
+    if echo "$name" | grep -q 'coredns-'; then
+        kubectl -n kube-system delete pods "$name"
+    fi
+done

--- a/01-deploy-ollama.sh
+++ b/01-deploy-ollama.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+
+OLLAMA_IMAGE=${1:-"ollama/ollama:latest"}
+
+echo "Checking if namespace ollama-dist exists..."
+if ! kubectl get namespace ollama-dist &> /dev/null; then
+    echo "Creating namespace ollama-dist..."
+    kubectl create namespace ollama-dist
+else
+    echo "Namespace ollama-dist already exists"
+fi
+
+echo "Creating ServiceAccount..."
+if ! kubectl get sa llama-sa -n ollama-dist &> /dev/null; then
+    echo "Creating ServiceAccount llama-sa..."
+    kubectl create sa llama-sa -n ollama-dist
+else
+    echo "ServiceAccount llama-sa already exists"
+fi
+
+echo "Creating Ollama deployment and service with image: $OLLAMA_IMAGE..."
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-server
+  namespace: ollama-dist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama-server
+  template:
+    metadata:
+      labels:
+        app: ollama-server
+    spec:
+      serviceAccountName: llama-sa
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+      - name: ollama-server
+        image: ${OLLAMA_IMAGE}
+        args: ["serve"]
+        ports:
+        - containerPort: 11434
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+        securityContext:
+          allowPrivilegeEscalation: true
+          runAsNonRoot: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-server-service
+  namespace: ollama-dist
+spec:
+  selector:
+    app: ollama-server
+  ports:
+  - protocol: TCP
+    port: 11434
+    targetPort: 11434
+  type: ClusterIP
+EOF
+
+echo "Waiting for Ollama deployment to be ready..."
+kubectl rollout status deployment/ollama-server -n ollama-dist
+
+POD_NAME=$(kubectl get pods -n ollama-dist -l app=ollama-server -o name |  head -n1)
+
+echo "Running llama3.2:1b model..."
+kubectl exec -n ollama-dist $POD_NAME -- ollama run llama3.2:1b --keepalive 60m

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# llama-stack-tasks
+# Riding a stack of Llamas 🦙
+
+Describes some experiments w/ the LLama Stack.
+
+## Setup Kubernetes and Ollama Server
+
+### Run your (local) K8S
+
+```shell
+./00-run-k8s.sh
+```
+
+### Run your ollama server
+
+```shell
+./01-deploy-ollama.sh
+```
+
+## The Llama Stack distribution
+
+### Install the LlamaStack Operator
+
+```
+kubectl apply -f https://raw.githubusercontent.com/llamastack/llama-stack-k8s-operator/main/release/operator.yaml
+```
+
+### The `LlamaStackDistribution` 
+
+```shell
+cat <<-EOF | kubectl apply -f -
+apiVersion: llamastack.io/v1alpha1
+kind: LlamaStackDistribution
+metadata:
+  name: llamastackdistribution-sample
+spec:
+  replicas: 1
+  server:
+    distribution:
+      name: ollama
+    containerSpec:
+      env:
+      - name: INFERENCE_MODEL
+        value: llama3.2:1b
+      - name: OLLAMA_URL
+        value: http://ollama-server-service.ollama-dist.svc.cluster.local:11434
+      name: llama-stack
+      resources: {}
+    storage:
+      mountPath: /home/lls/.lls
+      size: 20Gi
+EOF
+```
+
+After a couple of minutes, the `Container` should be created, and you see:
+
+```
+k get llamastackdistribution.llamastack.io
+NAME                            VERSION   READY
+llamastackdistribution-sample             true
+```

--- a/llama.yaml
+++ b/llama.yaml
@@ -1,0 +1,20 @@
+apiVersion: llamastack.io/v1alpha1
+kind: LlamaStackDistribution
+metadata:
+  name: llamastackdistribution-sample
+spec:
+  replicas: 1
+  server:
+    distribution:
+      name: ollama
+    containerSpec:
+      env:
+      - name: INFERENCE_MODEL
+        value: llama3.2:1b
+      - name: OLLAMA_URL
+        value: http://ollama-server-service.ollama-dist.svc.cluster.local:11434
+      name: llama-stack
+      resources: {}
+    storage:
+      mountPath: /home/lls/.lls
+      size: 20Gi


### PR DESCRIPTION
Adding `README` and scripts to guide for an installation of the `LLamastack` Operator.

* kind (locally)
* ollama 
* install the operator
* create an instance of a LLamastack distribution