### PR TITLE
Rename env var for llama stack host

### DIFF
--- a/inference-func/func.yaml
+++ b/inference-func/func.yaml
@@ -11,7 +11,7 @@ build:
   builder: host
 run:
   envs:
-  - name: LSD_HOST
+  - name: LLSD_HOST
     value: http://llamastackdistribution-sample-service.default.svc.cluster.local:8321
 deploy:
   namespace: default

--- a/inference-func/function/func.py
+++ b/inference-func/function/func.py
@@ -22,7 +22,7 @@ class Function:
         configuration.
         """
         logging.info("Connecting to LLama Stack")
-        self.client = LlamaStackClient(base_url=os.environ.get("LSD_HOST", "http://localhost:8321"))
+        self.client = LlamaStackClient(base_url=os.environ.get("LLSD_HOST", "http://localhost:8321"))
         models = self.client.models.list()
 
         # Select the first LLM


### PR DESCRIPTION
Rename env var for llama stack host, to match the new shortName for the CRD (llsd)