### PR TITLE
Update llsd configuration to support latest llama stack server

### DIFF
--- a/config/llamastack-distro/00-llamastackdistribution.yaml
+++ b/config/llamastack-distro/00-llamastackdistribution.yaml
@@ -6,13 +6,15 @@ spec:
   replicas: 1
   server:
     distribution:
-      name: ollama
+      name: starter
     containerSpec:
       env:
-      - name: INFERENCE_MODEL
+      - name: OLLAMA_INFERENCE_MODEL
         value: llama3.2:1b
       - name: OLLAMA_URL
         value: http://ollama-server-service.ollama-dist.svc.cluster.local:11434
+      - name: ENABLE_OLLAMA
+        value: ollama
       name: llama-stack
       resources: {}
     storage:


### PR DESCRIPTION
based on discussions on PR https://github.com/llamastack/llama-stack-k8s-operator/pull/96/. Seems like ollama distribution is not longer maintained and switching to 'starter', and adjustments for OLLAMA env settings